### PR TITLE
replace fuzzywuzzy with rapidfuzz

### DIFF
--- a/ha_client.py
+++ b/ha_client.py
@@ -1,5 +1,5 @@
 from requests import get, post
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import json
 from requests.exceptions import Timeout, RequestException
 
@@ -69,7 +69,7 @@ class HomeAssistantClient(object):
                         # and repetitions should not count on my behalf
                         score = fuzz.token_sort_ratio(
                             entity,
-                            state['attributes']['friendly_name'].lower())
+                            state['attributes']['friendly_name'])
                         if score > best_score:
                             best_score = score
                             best_entity = {
@@ -80,7 +80,7 @@ class HomeAssistantClient(object):
                                 "best_score": best_score}
                         score = fuzz.token_sort_ratio(
                             entity,
-                            state['entity_id'].lower())
+                            state['entity_id'])
                         if score > best_score:
                             best_score = score
                             best_entity = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fuzzywuzzy==0.14.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.2.0
 requests
 responses


### PR DESCRIPTION
Für eines meiner Projekte habe ich bisher ebenfalls fuzzywuzzy genutzt. Leider ist mir kürzlich aufgefallen, dass fuzzywuzzy unter einer GPLv2 Lizenz steht. Dementsprechend muss jedes Projekt, dass die Library nutzt ebenfalls unter einer GPLv2 stehen.

In Folge dessen habe ich auf Basis einer alten Version von FuzzyWuzzy die damals unter einer MIT Lizenz stand RapidFuzz geschrieben. Diese nutzt die selben Algorithmen wie FuzzyWuzzy, aber steht unter einer MIT Lizenz und kann entsprechend auch mit anderen Lizenzen wie hier der LGPL3 genutzt werden. Als nettes extra ist RapidFuzz je nach String der verglichen werden soll zwischen 5 und 100 mal so schnell wie FuzzyWuzzy